### PR TITLE
When device is unlocked, a '0' gets written [iOS 9.3.5]

### DIFF
--- a/modules/coreduetd_device_lock_state.txt
+++ b/modules/coreduetd_device_lock_state.txt
@@ -16,8 +16,8 @@ KEY_TIMESTAMP=CREATE TIME
 QUERY=
 	SELECT 
 		CASE ZLOCKSTATE
-		    WHEN "0" THEN "Locked"
-		    WHEN "1" THEN "Unlocked"
+		    WHEN "0" THEN "Unlocked"
+		    WHEN "1" THEN "Llocked"
 		END "LOCK STATE",
 		DATETIME(ZCREATIONDATE+978307200,"unixepoch") as "CREATE TIME",
 		TIME(ZLOCALTIME,"unixepoch") as "LOCAL DEVICE TIME",

--- a/modules/coreduetd_device_lock_state.txt
+++ b/modules/coreduetd_device_lock_state.txt
@@ -17,7 +17,7 @@ QUERY=
 	SELECT 
 		CASE ZLOCKSTATE
 		    WHEN "0" THEN "Unlocked"
-		    WHEN "1" THEN "Llocked"
+		    WHEN "1" THEN "Locked"
 		END "LOCK STATE",
 		DATETIME(ZCREATIONDATE+978307200,"unixepoch") as "CREATE TIME",
 		TIME(ZLOCALTIME,"unixepoch") as "LOCAL DEVICE TIME",


### PR DESCRIPTION
I tested this on a jailbroken iPad A1416, running iOS 9.3.5. When I unlocked the device, a '0' was written to ZCDDMSCREENLOCKEVENT.ZLOCKSTATE. And vice versa, when the device got locked, a '1' was written to the same table