### PR TITLE
Fix failed non-ascii conversion

### DIFF
--- a/apollo.py
+++ b/apollo.py
@@ -159,8 +159,11 @@ def run_module(mod_name,query_name,database_names,activity,key_timestamp,sql_que
 				data_stuff = ""
 
 				for k,v in six.iteritems(col_row):
-		
-					data = "[" + str(k) + ": " + str(v) + "] "
+					# changed due to errors popping up when v contains non-ascii characters (e.g. euro symbol)
+					try:
+						data = "[" + str(k) + ": " + str(v.encode('ascii', 'ignore')) + "] "
+					except AttributeError:
+						data = "[" + str(k) + ": " + 'None' + "] "
 
 					try:
 						data_stuff = data_stuff + data


### PR DESCRIPTION
Fixes errors when the value contains unicode (e.g. the euro sign). Previously it would for example return : 'ascii codec can't encode character u'\u20ac' in position x, ordinal not in range(128). It was caught by the Exception handler lower, incorrectly suggesting it was due to file permissions.

Patch now ignores non-ascii -encodable characters; it will drop the non-encodable characters